### PR TITLE
Add meal history page with navigation links

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,19 @@
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID!
+};
+
+const app = initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+interface Meal {
+  id: number;
+  mealName: string;
+  date: Date;
+}
+
+export default function History() {
+  const meals: Meal[] = [
+    { id: 1, mealName: "Spaghetti", date: new Date() },
+    { id: 2, mealName: "Tacos", date: new Date() }
+  ];
+
+  return (
+    <main>
+      <h1>Meal History</h1>
+      <Link href="/meals">Add Meal</Link>
+      <ul>
+        {meals.map(m => (
+          <li key={m.id}>
+            {m.date.toLocaleDateString()} – {m.mealName}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { auth } from "@/lib/firebaseClient";
+import { auth } from "@/lib/firebase";
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from "firebase/auth";
 import { useRouter } from "next/router";
 

--- a/src/pages/meals.tsx
+++ b/src/pages/meals.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { auth, db } from "@/lib/firebaseClient";
+import { auth, db } from "@/lib/firebase";
 import { onAuthStateChanged, signOut } from "firebase/auth";
 import { collection, addDoc, query, orderBy, onSnapshot, Timestamp } from "firebase/firestore";
+import Link from "next/link";
 
 interface Meal {
   id: string;
@@ -41,6 +42,7 @@ export default function Meals() {
     <main>
       <h1>Meals</h1>
       <button onClick={() => signOut(auth)}>Log Out</button>
+      <Link href="/history">History</Link>
       <div>
         <input type="date" value={date} onChange={e => setDate(e.target.value)} />
         <input placeholder="Meal name" value={mealName} onChange={e => setMealName(e.target.value)} />


### PR DESCRIPTION
## Summary
- add a simple Firebase wrapper for tests
- introduce a history page listing temporary meals and link back to meal form
- add navigation link from meals page to visit history

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c26bc910c88331a38ed298a9b9d7d5