### PR TITLE
feat: cache meals locally before syncing to Firestore

### DIFF
--- a/__tests__/firebase.test.ts
+++ b/__tests__/firebase.test.ts
@@ -2,7 +2,11 @@ import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
-jest.mock('firebase/app', () => ({ initializeApp: jest.fn(() => 'app') }));
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(() => 'app'),
+  getApps: jest.fn(() => []),
+  getApp: jest.fn(() => 'app'),
+}));
 jest.mock('firebase/auth', () => ({ getAuth: jest.fn(() => 'auth') }));
 jest.mock('firebase/firestore', () => ({ getFirestore: jest.fn(() => 'db') }));
 
@@ -19,7 +23,7 @@ test('initializes firebase with env config', () => {
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'appid';
   process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID = 'measure';
 
-  const { auth, db } = require('@/lib/firebase');
+  const { auth, db } = require('@/lib/firebaseClient');
 
   expect(initializeApp).toHaveBeenCalledWith({
     apiKey: 'key',

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-jest.mock('@/lib/firebase', () => ({ auth: {} }));
+jest.mock('@/lib/firebaseClient', () => ({ auth: {} }));
 
 jest.mock('firebase/auth', () => ({
   signInWithEmailAndPassword: jest.fn(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "recipe-tracker",
       "dependencies": {
         "firebase": "^11.10.0",
+        "idb": "^8.0.3",
         "next": "^14.2.32",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -682,6 +683,12 @@
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
       "license": "Apache-2.0"
     },
+    "node_modules/@firebase/app/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/@firebase/auth-compat": {
       "version": "0.5.28",
       "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.28.tgz",
@@ -950,6 +957,12 @@
         "@firebase/app-types": "0.x"
       }
     },
+    "node_modules/@firebase/installations/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/@firebase/logger": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
@@ -999,6 +1012,12 @@
       "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
       "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/messaging/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/@firebase/performance": {
       "version": "0.7.7",
@@ -4986,9 +5005,9 @@
       }
     },
     "node_modules/idb": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
     },
     "node_modules/identity-obj-proxy": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "firebase": "^11.10.0",
+    "idb": "^8.0.3",
     "next": "^14.2.32",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/src/lib/mealsStore.ts
+++ b/src/lib/mealsStore.ts
@@ -1,0 +1,62 @@
+import { openDB, type IDBPDatabase, type DBSchema } from 'idb';
+import { Timestamp } from 'firebase/firestore';
+
+export interface Meal {
+  id: string;
+  mealName: string;
+  date: Timestamp;
+  uid?: string;
+  pending?: boolean;
+}
+
+interface MealDB extends DBSchema {
+  meals: {
+    key: string;
+    value: Meal;
+  };
+}
+
+let dbPromise: Promise<IDBPDatabase<MealDB>> | null = null;
+
+function getDb() {
+  if (dbPromise) return dbPromise;
+  if (typeof window === 'undefined' || !("indexedDB" in window)) {
+    return null;
+  }
+  dbPromise = openDB<MealDB>('recipe-tracker', 1, {
+    upgrade(db) {
+      db.createObjectStore('meals', { keyPath: 'id' });
+    },
+  });
+  return dbPromise;
+}
+
+export async function getAllMeals(): Promise<Meal[]> {
+  const db = getDb();
+  if (!db) return [];
+  return (await db).getAll('meals');
+}
+
+export async function saveMeal(meal: Meal) {
+  const db = getDb();
+  if (!db) return;
+  await (await db).put('meals', meal);
+}
+
+export async function getPendingMeals(): Promise<Meal[]> {
+  const meals = await getAllMeals();
+  return meals.filter(m => m.pending);
+}
+
+export async function markMealSynced(localId: string, newId: string) {
+  const db = getDb();
+  if (!db) return;
+  const inst = await db;
+  const meal = await inst.get('meals', localId);
+  if (meal) {
+    await inst.delete('meals', localId);
+    meal.id = newId;
+    meal.pending = false;
+    await inst.put('meals', meal);
+  }
+}

--- a/src/pages/meals.tsx
+++ b/src/pages/meals.tsx
@@ -2,39 +2,85 @@ import { useEffect, useState } from "react";
 import { auth, db } from "@/lib/firebaseClient";
 import { onAuthStateChanged, signOut } from "firebase/auth";
 import { collection, addDoc, query, orderBy, onSnapshot, Timestamp } from "firebase/firestore";
-
-interface Meal {
-  id: string;
-  mealName: string;
-  date: Timestamp;
-}
+import {
+  getAllMeals,
+  saveMeal,
+  getPendingMeals,
+  markMealSynced,
+  type Meal,
+} from "@/lib/mealsStore";
 
 export default function Meals() {
   const [mealName, setMealName] = useState("");
   const [date, setDate] = useState("");
   const [meals, setMeals] = useState<Meal[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const unsubAuth = onAuthStateChanged(auth, user => {
       if (!user) window.location.href = "/";
     });
+    getAllMeals().then(ms =>
+      setMeals(ms.sort((a, b) => b.date.toMillis() - a.date.toMillis()))
+    );
     const q = query(collection(db, "meals"), orderBy("date", "desc"));
-    const unsubMeals = onSnapshot(q, snap => {
-      setMeals(snap.docs.map(d => ({ id: d.id, ...(d.data() as any) })));
+    const unsubMeals = onSnapshot(q, async snap => {
+      const serverMeals = snap.docs.map(d => ({
+        id: d.id,
+        ...(d.data() as any),
+        pending: false,
+      }));
+      for (const m of serverMeals) await saveMeal(m);
+      const pending = await getPendingMeals();
+      setMeals(
+        [...serverMeals, ...pending].sort(
+          (a, b) => b.date.toMillis() - a.date.toMillis()
+        )
+      );
     });
+    syncPendingMeals();
     return () => {
       unsubAuth();
       unsubMeals();
     };
   }, []);
 
+  async function syncPendingMeals() {
+    const pending = await getPendingMeals();
+    for (const m of pending) {
+      try {
+        const docRef = await addDoc(collection(db, "meals"), {
+          mealName: m.mealName,
+          date: m.date,
+          uid: m.uid,
+        });
+        await markMealSynced(m.id, docRef.id);
+      } catch {
+        // ignore offline errors
+      }
+    }
+    const all = await getAllMeals();
+    setMeals(all.sort((a, b) => b.date.toMillis() - a.date.toMillis()));
+  }
+
   async function addMeal() {
-    await addDoc(collection(db, "meals"), {
+    const newMeal: Meal = {
+      id: Date.now().toString(),
       mealName,
       date: date ? Timestamp.fromDate(new Date(date)) : Timestamp.now(),
-      uid: auth.currentUser?.uid
-    });
+      uid: auth.currentUser?.uid,
+      pending: true,
+    };
+    await saveMeal(newMeal);
+    setMeals(prev =>
+      [newMeal, ...prev].sort(
+        (a, b) => b.date.toMillis() - a.date.toMillis()
+      )
+    );
     setMealName("");
+    setMessage("Meal saved locally");
+    setTimeout(() => setMessage(null), 2000);
+    syncPendingMeals();
   }
 
   return (
@@ -46,6 +92,7 @@ export default function Meals() {
         <input placeholder="Meal name" value={mealName} onChange={e => setMealName(e.target.value)} />
         <button onClick={addMeal}>Add Meal</button>
       </div>
+      {message && <p>{message}</p>}
       <ul>
         {meals.map(m => (
           <li key={m.id}>


### PR DESCRIPTION
## Summary
- save new meals to IndexedDB for instant history updates and offline support
- sync pending meals to Firestore in the background
- show a local save confirmation when adding meals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2815837088331ba5fa22135bd9c4f