### PR TITLE
Add meal history screen

### DIFF
--- a/__tests__/history.test.tsx
+++ b/__tests__/history.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, act } from '@testing-library/react';
+
+// Polyfill for next/link usage in tests
+(document as any).createRange = () => ({
+  setStart: () => {},
+  setEnd: () => {},
+  commonAncestorContainer: document.createElement('div')
+});
+
+jest.mock('@/lib/mealsStore', () => ({
+  getAllMeals: jest.fn()
+}));
+
+import { getAllMeals } from '@/lib/mealsStore';
+
+const Page = require('@/pages/history').default;
+
+test('renders meals in reverse chronological order', async () => {
+  (getAllMeals as jest.Mock).mockResolvedValue([
+    {
+      id: '1',
+      mealName: 'Chicken Stir Fry',
+      date: {
+        toDate: () => new Date('2024-03-15'),
+        toMillis: () => new Date('2024-03-15').getTime()
+      }
+    },
+    {
+      id: '2',
+      mealName: 'Pasta Carbonara',
+      date: {
+        toDate: () => new Date('2024-03-14'),
+        toMillis: () => new Date('2024-03-14').getTime()
+      }
+    }
+  ]);
+
+  await act(async () => {
+    render(<Page />);
+  });
+
+  const rows = screen.getAllByRole('row').slice(1); // skip header
+  expect(rows[0]).toHaveTextContent('Chicken Stir Fry');
+  expect(rows[1]).toHaveTextContent('Pasta Carbonara');
+});
+
+test('shows message when there are no meals', async () => {
+  (getAllMeals as jest.Mock).mockResolvedValue([]);
+
+  await act(async () => {
+    render(<Page />);
+  });
+
+  expect(screen.getByText('No meals recorded.')).toBeInTheDocument();
+});

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { getAllMeals, type Meal } from "@/lib/mealsStore";
+
+export default function History() {
+  const [meals, setMeals] = useState<Meal[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const all = await getAllMeals();
+      all.sort((a, b) => b.date.toMillis() - a.date.toMillis());
+      setMeals(all);
+    }
+    load();
+  }, []);
+
+  return (
+    <main className="container">
+      <nav className="top-nav">
+        <Link href="/" className="nav-item">
+          Add
+        </Link>
+        <Link href="/history" className="nav-item active">
+          History
+        </Link>
+        <button className="nav-item" disabled>
+          Ideas
+        </button>
+      </nav>
+      <h1>History</h1>
+      {meals.length > 0 ? (
+        <>
+          <p className="subtitle">
+            {meals.length} meal{meals.length === 1 ? "" : "s"} tracked
+          </p>
+          <table className="history-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Meal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {meals.map(meal => (
+                <tr key={meal.id}>
+                  <td>
+                    {meal
+                      .date.toDate()
+                      .toLocaleDateString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                  </td>
+                  <td>{meal.mealName}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      ) : (
+        <p>No meals recorded.</p>
+      )}
+    </main>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { auth, db } from "@/lib/firebaseClient";
 import { collection, addDoc, Timestamp } from "firebase/firestore";
 import {
@@ -54,10 +55,12 @@ export default function Meals() {
   return (
     <main className="container">
       <nav className="top-nav">
-        <button className="nav-item active">Add</button>
-        <button className="nav-item" disabled>
+        <Link href="/" className="nav-item active">
+          Add
+        </Link>
+        <Link href="/history" className="nav-item">
           History
-        </button>
+        </Link>
         <button className="nav-item" disabled>
           Ideas
         </button>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -80,3 +80,23 @@ body {
   color: #16a34a;
 }
 
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  margin-top: 1rem;
+}
+
+.history-table th,
+.history-table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+}
+
+.history-table tbody tr:nth-child(even) {
+  background: #f9fafb;
+}
+


### PR DESCRIPTION
## Summary
- add history page showing saved meals in reverse chronological order
- update navigation links and add styling for history table
- test history page rendering and empty state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a208d92c8331b1d5986b74a04640