### PR TITLE
Add ideas screen to display unique recipes

### DIFF
--- a/__tests__/ideas.test.tsx
+++ b/__tests__/ideas.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, act } from '@testing-library/react';
+
+// Polyfill for next/link usage in tests
+(document as any).createRange = () => ({
+  setStart: () => {},
+  setEnd: () => {},
+  commonAncestorContainer: document.createElement('div')
+});
+
+jest.mock('@/lib/mealsStore', () => ({
+  getAllMeals: jest.fn(),
+}));
+
+import { getAllMeals } from '@/lib/mealsStore';
+
+const Page = require('@/pages/ideas').default;
+
+test('renders unique meals with counts', async () => {
+  (getAllMeals as jest.Mock).mockResolvedValue([
+    {
+      id: '1',
+      mealName: 'Chicken Stir Fry',
+      date: {
+        toDate: () => new Date('2024-03-15'),
+        toMillis: () => new Date('2024-03-15').getTime(),
+      },
+    },
+    {
+      id: '2',
+      mealName: 'Pasta Carbonara',
+      date: {
+        toDate: () => new Date('2024-03-14'),
+        toMillis: () => new Date('2024-03-14').getTime(),
+      },
+    },
+    {
+      id: '3',
+      mealName: 'Chicken Stir Fry',
+      date: {
+        toDate: () => new Date('2024-03-13'),
+        toMillis: () => new Date('2024-03-13').getTime(),
+      },
+    },
+  ]);
+
+  await act(async () => {
+    render(<Page />);
+  });
+
+  const rows = screen.getAllByRole('row').slice(1); // skip header
+  expect(rows).toHaveLength(2);
+  expect(rows[0]).toHaveTextContent('Chicken Stir Fry');
+  expect(rows[0]).toHaveTextContent('2x');
+  expect(rows[1]).toHaveTextContent('Pasta Carbonara');
+  expect(rows[1]).toHaveTextContent('1x');
+});
+
+test('shows message when there are no meals', async () => {
+  (getAllMeals as jest.Mock).mockResolvedValue([]);
+
+  await act(async () => {
+    render(<Page />);
+  });
+
+  expect(screen.getByText('No meals recorded.')).toBeInTheDocument();
+});
+

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -23,9 +23,9 @@ export default function History() {
         <Link href="/history" className="nav-item active">
           History
         </Link>
-        <button className="nav-item" disabled>
+        <Link href="/ideas" className="nav-item">
           Ideas
-        </button>
+        </Link>
       </nav>
       <h1>History</h1>
       {meals.length > 0 ? (

--- a/src/pages/ideas.tsx
+++ b/src/pages/ideas.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { getAllMeals, type Meal } from "@/lib/mealsStore";
+
+interface Idea {
+  mealName: string;
+  lastMade: Meal["date"];
+  count: number;
+}
+
+export default function Ideas() {
+  const [ideas, setIdeas] = useState<Idea[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const all = await getAllMeals();
+      const map = new Map<string, Idea>();
+      for (const meal of all) {
+        const existing = map.get(meal.mealName);
+        if (existing) {
+          existing.count += 1;
+          if (meal.date.toMillis() > existing.lastMade.toMillis()) {
+            existing.lastMade = meal.date;
+          }
+        } else {
+          map.set(meal.mealName, {
+            mealName: meal.mealName,
+            lastMade: meal.date,
+            count: 1,
+          });
+        }
+      }
+      const arr = Array.from(map.values());
+      arr.sort(
+        (a, b) =>
+          b.lastMade.toMillis() - a.lastMade.toMillis() ||
+          a.mealName.localeCompare(b.mealName)
+      );
+      setIdeas(arr);
+    }
+    load();
+  }, []);
+
+  return (
+    <main className="container">
+      <nav className="top-nav">
+        <Link href="/" className="nav-item">
+          Add
+        </Link>
+        <Link href="/history" className="nav-item">
+          History
+        </Link>
+        <Link href="/ideas" className="nav-item active">
+          Ideas
+        </Link>
+      </nav>
+      <h1>Ideas</h1>
+      {ideas.length > 0 ? (
+        <>
+          <p className="subtitle">
+            {ideas.length} unique meal{ideas.length === 1 ? "" : "s"}
+          </p>
+          <table className="ideas-table">
+            <thead>
+              <tr>
+                <th>Meal</th>
+                <th>Last Made</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ideas.map(idea => (
+                <tr key={idea.mealName}>
+                  <td>{idea.mealName}</td>
+                  <td>
+                    {idea.lastMade
+                      .toDate()
+                      .toLocaleDateString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                  </td>
+                  <td>
+                    <span className="count-badge">{idea.count}x</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      ) : (
+        <p>No meals recorded.</p>
+      )}
+    </main>
+  );
+}
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,9 +61,9 @@ export default function Meals() {
         <Link href="/history" className="nav-item">
           History
         </Link>
-        <button className="nav-item" disabled>
+        <Link href="/ideas" className="nav-item">
           Ideas
-        </button>
+        </Link>
       </nav>
       <h1>Add Meal</h1>
       <p className="subtitle">Track what you're cooking today</p>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -100,3 +100,33 @@ body {
   background: #f9fafb;
 }
 
+.ideas-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  margin-top: 1rem;
+}
+
+.ideas-table th,
+.ideas-table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+}
+
+.ideas-table tbody tr:nth-child(even) {
+  background: #f9fafb;
+}
+
+.count-badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.5rem;
+  background: #eff6ff;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+


### PR DESCRIPTION
## Summary
- show navigation link to Ideas on all pages
- add Ideas page summarizing unique meals with last made date and count
- style ideas table and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a5ac335c83319bb217673c8df8e5