### PR TITLE
Add account page and update navigation

### DIFF
--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import Link from "next/link";
+
+export default function Account() {
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+
+  return (
+    <main className="container">
+      <nav className="top-nav">
+        <Link href="/" className="nav-item">
+          + Add
+        </Link>
+        <Link href="/history" className="nav-item">
+          History
+        </Link>
+        <Link href="/ideas" className="nav-item">
+          Ideas
+        </Link>
+        <Link href="/account" className="nav-item active">
+          Account
+        </Link>
+      </nav>
+      <h1>Account</h1>
+      <p className="subtitle">Sign in or create your account</p>
+      <div className="auth-card">
+        <div className="auth-tabs">
+          <button
+            className={`auth-tab ${mode === "signin" ? "active" : ""}`}
+            onClick={() => setMode("signin")}
+          >
+            Sign In
+          </button>
+          <button
+            className={`auth-tab ${mode === "signup" ? "active" : ""}`}
+            onClick={() => setMode("signup")}
+          >
+            Sign Up
+          </button>
+        </div>
+        <div className="auth-fields">
+          <label>
+            Email Address
+            <input type="email" placeholder="Enter your email..." />
+          </label>
+          <label>
+            Password
+            <input type="password" placeholder="Enter your password..." />
+          </label>
+          <button className="auth-submit">
+            {mode === "signin" ? "Sign In" : "Sign Up"}
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -18,13 +18,16 @@ export default function History() {
     <main className="container">
       <nav className="top-nav">
         <Link href="/" className="nav-item">
-          Add
+          + Add
         </Link>
         <Link href="/history" className="nav-item active">
           History
         </Link>
         <Link href="/ideas" className="nav-item">
           Ideas
+        </Link>
+        <Link href="/account" className="nav-item">
+          Account
         </Link>
       </nav>
       <h1>History</h1>

--- a/src/pages/ideas.tsx
+++ b/src/pages/ideas.tsx
@@ -45,13 +45,16 @@ export default function Ideas() {
     <main className="container">
       <nav className="top-nav">
         <Link href="/" className="nav-item">
-          Add
+          + Add
         </Link>
         <Link href="/history" className="nav-item">
           History
         </Link>
         <Link href="/ideas" className="nav-item active">
           Ideas
+        </Link>
+        <Link href="/account" className="nav-item">
+          Account
         </Link>
       </nav>
       <h1>Ideas</h1>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -68,13 +68,16 @@ export default function Meals() {
     <main className="container">
       <nav className="top-nav">
         <Link href="/" className="nav-item active">
-          Add
+          + Add
         </Link>
         <Link href="/history" className="nav-item">
           History
         </Link>
         <Link href="/ideas" className="nav-item">
           Ideas
+        </Link>
+        <Link href="/account" className="nav-item">
+          Account
         </Link>
       </nav>
       <h1>Add Meal</h1>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -130,3 +130,61 @@ body {
   font-size: 0.875rem;
 }
 
+.auth-card {
+  background: white;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.auth-tabs {
+  display: flex;
+}
+
+.auth-tab {
+  flex: 1;
+  padding: 0.75rem;
+  background: none;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  color: #374151;
+}
+
+.auth-tab.active {
+  background: #eff6ff;
+  color: #2563eb;
+}
+
+.auth-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.auth-fields label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  color: #374151;
+}
+
+.auth-fields input {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+}
+
+.auth-submit {
+  padding: 0.75rem;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- create account page with sign-in and sign-up UI
- expand top navigation with Account link and iconized Add label
- add styles for account forms and tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3b4897b8083319a9b642c2989bdac