### PR TITLE
Cache tag metadata in ideas table rows

### DIFF
--- a/__tests__/IdeasTableRow.test.tsx
+++ b/__tests__/IdeasTableRow.test.tsx
@@ -1,0 +1,163 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import IdeasTableRow from '@/components/IdeasTableRow';
+import {
+  TAG_COLORS,
+  TAG_MANAGEMENT_UPDATED_EVENT,
+  TagManager,
+  type TagCategory,
+  type TagManagementData
+} from '@/lib/tag-manager';
+import type { Idea } from '@/hooks/useIdeas';
+
+jest.mock('@/lib/tag-manager', () => {
+  const actual = jest.requireActual('@/lib/tag-manager');
+  return {
+    ...actual,
+    TagManager: {
+      ...actual.TagManager,
+      getTagManagementData: jest.fn()
+    }
+  };
+});
+
+const mockedTagManager = TagManager as jest.Mocked<typeof TagManager>;
+
+const createMockTimestamp = (isoString: string): Idea['lastMade'] => ({
+  toDate: () => new Date(isoString),
+  toMillis: () => new Date(isoString).getTime()
+} as unknown as Idea['lastMade']);
+
+const createIdea = (overrides: Partial<Idea> = {}): Idea => ({
+  mealName: 'Test Meal',
+  lastMade: createMockTimestamp('2024-01-01T00:00:00Z'),
+  count: 1,
+  hidden: false,
+  tags: ['Spicy'],
+  ...overrides
+});
+
+const renderRow = (idea: Idea) =>
+  render(
+    <table>
+      <tbody>
+        <IdeasTableRow idea={idea} onConfirmHide={jest.fn()} />
+      </tbody>
+    </table>
+  );
+
+const createTagManagementData = (data: Partial<TagManagementData>) => ({
+  categories: [],
+  tags: {},
+  ...data
+}) as TagManagementData;
+
+describe('IdeasTableRow tag metadata caching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads tag metadata once and reuses cached colors on re-render', async () => {
+    const categories: TagCategory[] = [
+      { id: 'spice', name: 'Spice', color: 'pink', createdAt: Date.now() }
+    ];
+    mockedTagManager.getTagManagementData.mockReturnValue(
+      createTagManagementData({
+        categories,
+        tags: {
+          Spicy: { category: 'spice' }
+        }
+      })
+    );
+
+    const idea = createIdea();
+    const { rerender } = renderRow(idea);
+
+    await waitFor(() =>
+      expect(mockedTagManager.getTagManagementData).toHaveBeenCalledTimes(1)
+    );
+
+    expect(screen.getByText('Spicy')).toHaveStyle(
+      `background-color: ${TAG_COLORS.pink}`
+    );
+
+    rerender(
+      <table>
+        <tbody>
+          <IdeasTableRow
+            idea={{ ...idea, count: 2 }}
+            onConfirmHide={jest.fn()}
+          />
+        </tbody>
+      </table>
+    );
+
+    expect(mockedTagManager.getTagManagementData).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes cached metadata when tag settings change', async () => {
+    const initialData = createTagManagementData({
+      categories: [
+        { id: 'spice', name: 'Spice', color: 'pink', createdAt: Date.now() }
+      ],
+      tags: {
+        Spicy: { category: 'spice' }
+      }
+    });
+
+    const updatedData = createTagManagementData({
+      categories: [
+        { id: 'spice', name: 'Spice', color: 'blue', createdAt: Date.now() }
+      ],
+      tags: {
+        Spicy: { category: 'spice' }
+      }
+    });
+
+    let currentData = initialData;
+    mockedTagManager.getTagManagementData.mockImplementation(() => currentData);
+
+    renderRow(createIdea());
+
+    await waitFor(() =>
+      expect(mockedTagManager.getTagManagementData).toHaveBeenCalledTimes(1)
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Spicy')).toHaveStyle(
+        `background-color: ${TAG_COLORS.pink}`
+      )
+    );
+
+    act(() => {
+      currentData = updatedData;
+      window.dispatchEvent(new CustomEvent(TAG_MANAGEMENT_UPDATED_EVENT));
+    });
+
+    await waitFor(() =>
+      expect(mockedTagManager.getTagManagementData).toHaveBeenCalledTimes(2)
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Spicy')).toHaveStyle(
+        `background-color: ${TAG_COLORS.blue}`
+      )
+    );
+  });
+
+  it('falls back to gray when metadata is unavailable', async () => {
+    mockedTagManager.getTagManagementData.mockReturnValue(
+      createTagManagementData({ tags: {} })
+    );
+
+    renderRow(createIdea({ tags: ['Unknown'] }));
+
+    await waitFor(() =>
+      expect(mockedTagManager.getTagManagementData).toHaveBeenCalledTimes(1)
+    );
+
+    expect(screen.getByText('Unknown')).toHaveStyle(
+      `background-color: ${TAG_COLORS.gray}`
+    );
+  });
+});
+

--- a/src/lib/tag-manager.ts
+++ b/src/lib/tag-manager.ts
@@ -42,6 +42,8 @@ export const DEFAULT_CATEGORIES: TagCategory[] = [
   { id: 'dietary', name: 'Dietary', color: 'lavender', createdAt: Date.now() }
 ];
 
+export const TAG_MANAGEMENT_UPDATED_EVENT = 'tag-management-updated';
+
 export class TagManager {
   private static readonly STORAGE_KEY = 'dish-diary-tag-management';
 
@@ -66,6 +68,11 @@ export class TagManager {
   static saveTagManagementData(data: TagManagementData): void {
     try {
       localStorage.setItem(this.STORAGE_KEY, JSON.stringify(data));
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent(TAG_MANAGEMENT_UPDATED_EVENT, { detail: data })
+        );
+      }
     } catch (error) {
       console.error('Error saving tag management data:', error);
     }


### PR DESCRIPTION
## Summary
- cache tag metadata and categories in the ideas table row component and refresh them when tag settings change
- emit a browser event whenever tag management data is saved so cached consumers can update in place
- add regression tests around IdeasTableRow tag coloring, metadata refresh, and fallback behavior

## Testing
- npm test
- npm run lint *(warnings only; pre-existing repository issues)*
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cb44fcc5688331be274e7479cde996