### PR TITLE
Add interactive tag actions modal to ideas table

### DIFF
--- a/src/components/TagActionsModal.tsx
+++ b/src/components/TagActionsModal.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useId, useMemo, useState } from 'react';
+import type { ChangeEvent, FC, FormEvent } from 'react';
+
+interface TagActionsModalProps {
+  mealName: string;
+  tag: string;
+  tags: string[];
+  onClose: () => void;
+  onTagsUpdated: (mealName: string, tags: string[]) => void;
+}
+
+const TagActionsModal: FC<TagActionsModalProps> = ({
+  mealName,
+  tag,
+  tags,
+  onClose,
+  onTagsUpdated
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [renameValue, setRenameValue] = useState(tag);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const renameInputId = useId();
+
+  useEffect(() => {
+    setIsEditing(false);
+    setShowDeleteConfirm(false);
+    setRenameValue(tag);
+    setError(null);
+  }, [tag]);
+
+  const trimmedRename = useMemo(() => renameValue.trim(), [renameValue]);
+
+  const hasDuplicateName = useMemo(
+    () =>
+      tags.some(existingTag =>
+        existingTag.toLowerCase() === trimmedRename.toLowerCase() &&
+        existingTag.toLowerCase() !== tag.toLowerCase()
+      ),
+    [tags, trimmedRename, tag]
+  );
+
+  const handleClose = () => {
+    setIsEditing(false);
+    setShowDeleteConfirm(false);
+    setRenameValue(tag);
+    setError(null);
+    onClose();
+  };
+
+  const handleRenameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setRenameValue(event.target.value);
+    if (error) {
+      setError(null);
+    }
+  };
+
+  const handleRenameSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (trimmedRename === '') {
+      setError('Tag name cannot be empty.');
+      return;
+    }
+
+    if (hasDuplicateName) {
+      setError('This dish already uses that tag name.');
+      return;
+    }
+
+    if (trimmedRename === tag) {
+      setIsEditing(false);
+      setRenameValue(tag);
+      return;
+    }
+
+    const updatedTags = tags.map(existingTag =>
+      existingTag === tag ? trimmedRename : existingTag
+    );
+
+    onTagsUpdated(mealName, updatedTags);
+    handleClose();
+  };
+
+  const handleStartRename = () => {
+    setIsEditing(true);
+    setShowDeleteConfirm(false);
+    setError(null);
+  };
+
+  const handleCancelRename = () => {
+    setIsEditing(false);
+    setRenameValue(tag);
+    setError(null);
+  };
+
+  const handleStartDelete = () => {
+    setShowDeleteConfirm(true);
+    setIsEditing(false);
+    setError(null);
+  };
+
+  const handleCancelDelete = () => {
+    setShowDeleteConfirm(false);
+    setError(null);
+  };
+
+  const handleConfirmDelete = () => {
+    const updatedTags = tags.filter(existingTag => existingTag !== tag);
+    onTagsUpdated(mealName, updatedTags);
+    handleClose();
+  };
+
+  const isSaveDisabled =
+    trimmedRename === '' || trimmedRename === tag || hasDuplicateName;
+
+  return (
+    <div className="modal-overlay" onClick={handleClose}>
+      <div
+        className="modal-content tag-actions-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${renameInputId}-title`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2 id={`${renameInputId}-title`}>Tag Options</h2>
+          <button className="modal-close" onClick={handleClose} aria-label="Close">×</button>
+        </div>
+
+        <div className="modal-body tag-actions-body">
+          <div className="tag-actions-summary">
+            <span className="tag-actions-label">Dish</span>
+            <span className="tag-actions-value">{mealName}</span>
+          </div>
+
+          <div className="tag-actions-summary">
+            <span className="tag-actions-label">Tag</span>
+            <span className="tag-actions-value tag-actions-chip">{tag}</span>
+          </div>
+
+          {!isEditing && !showDeleteConfirm && (
+            <div className="tag-actions-options">
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={handleStartRename}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="danger-button"
+                onClick={handleStartDelete}
+              >
+                Delete
+              </button>
+            </div>
+          )}
+
+          {isEditing && (
+            <form className="tag-rename-form" onSubmit={handleRenameSubmit}>
+              <label htmlFor={renameInputId} className="tag-actions-label">
+                Rename tag
+              </label>
+              <input
+                id={renameInputId}
+                type="text"
+                value={renameValue}
+                onChange={handleRenameChange}
+                className="form-input-compact"
+                placeholder="Enter new tag name"
+                autoFocus
+              />
+              {error && <p className="tag-action-error">{error}</p>}
+              {!error && hasDuplicateName && (
+                <p className="tag-action-error">This dish already uses that tag name.</p>
+              )}
+              <div className="modal-actions">
+                <button
+                  type="button"
+                  className="secondary-button"
+                  onClick={handleCancelRename}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="primary-button"
+                  disabled={isSaveDisabled}
+                >
+                  Save
+                </button>
+              </div>
+            </form>
+          )}
+
+          {showDeleteConfirm && (
+            <div className="tag-delete-confirm">
+              <p>
+                Remove "{tag}" from "{mealName}"?
+              </p>
+              <div className="modal-actions">
+                <button
+                  type="button"
+                  className="secondary-button"
+                  onClick={handleCancelDelete}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="danger-button"
+                  onClick={handleConfirmDelete}
+                >
+                  Remove Tag
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TagActionsModal;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1945,6 +1945,23 @@ h1 {
   white-space: nowrap;
 }
 
+.tag-chip-small.interactive-tag-chip {
+  cursor: pointer;
+  user-select: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  touch-action: manipulation;
+}
+
+.tag-chip-small.interactive-tag-chip:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.tag-chip-small.interactive-tag-chip:active {
+  transform: scale(0.97);
+}
+
 .more-tags {
   display: inline-block;
   color: #6b7280;
@@ -1958,6 +1975,93 @@ h1 {
   color: #9ca3af;
   font-size: 0.75rem;
   font-style: italic;
+}
+
+/* Tag actions modal */
+.tag-actions-modal {
+  max-width: 380px;
+  width: 100%;
+}
+
+.tag-actions-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tag-actions-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.tag-actions-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.tag-actions-value {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.tag-actions-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #374151;
+  width: fit-content;
+}
+
+.tag-actions-options {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.tag-actions-options button {
+  flex: 1;
+}
+
+.tag-rename-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tag-rename-form input {
+  width: 100%;
+}
+
+.tag-action-error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #b91c1c;
+}
+
+.tag-delete-confirm {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tag-delete-confirm p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #7f1d1d;
 }
 
 /* Make count column narrower to save space for tags */
@@ -1984,6 +2088,18 @@ h1 {
   .more-tags,
   .no-tags {
     font-size: 0.625rem;
+  }
+
+  .tag-actions-modal {
+    max-width: calc(100vw - 1.5rem);
+  }
+
+  .tag-actions-options {
+    flex-direction: column;
+  }
+
+  .tag-actions-options button {
+    width: 100%;
   }
 
   .ideas-table th:nth-child(3),


### PR DESCRIPTION
## Summary
- add long-press detection and accessible fallbacks to idea tag chips and wire a tag actions modal
- introduce a TagActionsModal component that supports inline rename/delete flows and refreshes tags on success
- extend global styles for interactive chips, the new modal layout, and delete confirmation states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2133b373c83319e06310fea62c3f7