### PR TITLE
Enable adding meals via Enter key

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -171,6 +171,15 @@ export default function Meals() {
                 // Delay hiding to allow clicks on suggestions
                 setTimeout(() => setShowSuggestions(false), 150);
               }}
+              onKeyDown={event => {
+                if (event.key === "Enter") {
+                  if (showSuggestions && filteredSuggestions.length > 0) {
+                    return;
+                  }
+                  event.preventDefault();
+                  addMeal();
+                }
+              }}
             />
             {showSuggestions && filteredSuggestions.length > 0 && (
               <div className="suggestions-dropdown">


### PR DESCRIPTION
## Summary
- trigger meal submission when pressing Enter inside the dish-name field to match the Add Dish button
- guard against accidental submissions when autocomplete suggestions are visible so suggestion clicks still work

## Testing
- npm run lint
- npm run type-check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d21bc2fa648331842aaf864e05f517