### PR TITLE
Enable dynamic Firebase config for messaging worker

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -3,54 +3,58 @@
 // Import Firebase scripts
 importScripts('https://www.gstatic.com/firebasejs/10.4.0/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/10.4.0/firebase-messaging-compat.js');
+importScripts('/api/firebase-config');
 
-// Firebase configuration (same as main app)
-const firebaseConfig = {
-  apiKey: "your-api-key-here",
-  authDomain: "your-project.firebaseapp.com",
-  projectId: "your-project-id",
-  storageBucket: "your-project.appspot.com",
-  messagingSenderId: "your-sender-id",
-  appId: "your-app-id",
-  measurementId: "your-measurement-id"
-};
+const firebaseConfig = self.firebaseConfig;
+delete self.firebaseConfig;
+let messaging = null;
 
-// Initialize Firebase
-firebase.initializeApp(firebaseConfig);
+try {
+  if (!firebaseConfig) {
+    throw new Error('Missing Firebase configuration in service worker');
+  }
 
-// Get messaging instance
-const messaging = firebase.messaging();
+  firebase.initializeApp(firebaseConfig);
+  messaging = firebase.messaging();
+  console.log('[firebase-messaging-sw.js] Firebase initialized for background messaging');
+} catch (error) {
+  console.error('[firebase-messaging-sw.js] Failed to initialize Firebase Messaging:', error);
+}
 
 // Handle background messages
-messaging.onBackgroundMessage((payload) => {
-  console.log('[firebase-messaging-sw.js] Received background message ', payload);
+if (messaging) {
+  messaging.onBackgroundMessage((payload) => {
+    console.log('[firebase-messaging-sw.js] Received background message ', payload);
 
-  const notificationTitle = payload.notification?.title || '🍽️ Dinner Time!';
-  const notificationOptions = {
-    body: payload.notification?.body || 'What did you eat for dinner today?',
-    icon: '/icon-192x192.png',
-    badge: '/icon-192x192.png',
-    tag: 'dinner-reminder',
-    requireInteraction: true,
-    data: {
-      type: 'dinner-reminder',
-      url: '/',
-      ...payload.data
-    },
-    actions: [
-      {
-        action: 'add-meal',
-        title: '📝 Add Meal'
+    const notificationTitle = payload.notification?.title || '🍽️ Dinner Time!';
+    const notificationOptions = {
+      body: payload.notification?.body || 'What did you eat for dinner today?',
+      icon: '/icon-192x192.png',
+      badge: '/icon-192x192.png',
+      tag: 'dinner-reminder',
+      requireInteraction: true,
+      data: {
+        type: 'dinner-reminder',
+        url: '/',
+        ...payload.data
       },
-      {
-        action: 'dismiss',
-        title: '✕ Dismiss'
-      }
-    ]
-  };
+      actions: [
+        {
+          action: 'add-meal',
+          title: '📝 Add Meal'
+        },
+        {
+          action: 'dismiss',
+          title: '✕ Dismiss'
+        }
+      ]
+    };
 
-  return self.registration.showNotification(notificationTitle, notificationOptions);
-});
+    return self.registration.showNotification(notificationTitle, notificationOptions);
+  });
+} else {
+  console.warn('[firebase-messaging-sw.js] Background messaging unavailable; onBackgroundMessage not registered');
+}
 
 // Handle notification clicks (for background notifications)
 self.addEventListener('notificationclick', (event) => {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -72,7 +72,11 @@ export async function getFCMToken(): Promise<string | null> {
       return null;
     }
 
-    const token = await getToken(messaging, { vapidKey });
+    const registration = await navigator.serviceWorker.ready;
+    const token = await getToken(messaging, {
+      vapidKey,
+      serviceWorkerRegistration: registration,
+    });
     console.log("FCM token retrieved:", token ? "✓" : "✗");
     return token;
   } catch (error) {

--- a/src/pages/api/firebase-config.ts
+++ b/src/pages/api/firebase-config.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type FirebaseConfig = {
+  apiKey: string;
+  authDomain: string;
+  projectId: string;
+  storageBucket: string;
+  messagingSenderId: string;
+  appId: string;
+  measurementId?: string;
+};
+
+type FirebaseConfigResponse = string;
+
+function buildFirebaseConfig(): FirebaseConfig | null {
+  const config: FirebaseConfig = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "",
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "",
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "",
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "",
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "",
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "",
+    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID ?? undefined,
+  };
+
+  const requiredKeys: Array<keyof FirebaseConfig> = [
+    "apiKey",
+    "authDomain",
+    "projectId",
+    "storageBucket",
+    "messagingSenderId",
+    "appId",
+  ];
+
+  const hasAllRequiredValues = requiredKeys.every((key) => Boolean(config[key]));
+
+  if (!hasAllRequiredValues) {
+    return null;
+  }
+
+  if (!config.measurementId) {
+    delete config.measurementId;
+  }
+
+  return config;
+}
+
+function buildResponseScript(config: FirebaseConfig | null): FirebaseConfigResponse {
+  if (!config) {
+    return [
+      "console.error('Firebase configuration is missing required values.');",
+      "self.firebaseConfig = null;",
+    ].join("\n");
+  }
+
+  const serializedConfig = JSON.stringify(config);
+  return `self.firebaseConfig = ${serializedConfig};`;
+}
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<FirebaseConfigResponse>,
+): void {
+  res.setHeader("Content-Type", "application/javascript");
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+
+  const firebaseConfig = buildFirebaseConfig();
+  const body = buildResponseScript(firebaseConfig);
+
+  res.status(200).send(body);
+}


### PR DESCRIPTION
## Summary
- expose the Firebase web config through a server API that reads the existing NEXT_PUBLIC variables
- teach the Firebase messaging service worker to import that dynamic config and guard initialization
- request FCM tokens with the registered service worker so push messaging reuses the existing worker

## Testing
- npm run lint
- npm run type-check
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d3474faeac833183149ffb2f48a9fa