### PR TITLE
docs: clarify fcm vapid setup and update workflows

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: npm ci && npm run build
+        env:
+          NEXT_PUBLIC_FIREBASE_VAPID_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_VAPID_KEY }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: npm ci && npm run build
+        env:
+          NEXT_PUBLIC_FIREBASE_VAPID_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_VAPID_KEY }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-reminder-deploy.yml
+++ b/.github/workflows/firebase-reminder-deploy.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       - name: Install Firebase CLI
-        run: npm install --global firebase-tools@12
+        run: npm install --global firebase-tools@13
 
       - name: Install function dependencies
         working-directory: functions

--- a/scheduler.md
+++ b/scheduler.md
@@ -9,7 +9,7 @@ hooking Firebase Cloud Functions and Cloud Scheduler into production.
 1. **Use the Blaze plan.** Scheduled Cloud Functions require a project with
    billing enabled. Upgrade the Firebase project if it is still on the Spark
    plan.
-2. **Install the CLI tools:** `firebase-tools` (v12+) and `gcloud`. Authenticate
+2. **Install the CLI tools:** `firebase-tools` (v13+) and `gcloud`. Authenticate
    with the Firebase project you deploy to:
 
    ```bash
@@ -17,6 +17,9 @@ hooking Firebase Cloud Functions and Cloud Scheduler into production.
    firebase use <your-project-id>
    gcloud auth login
    ```
+
+   > **Tip:** If the deploy command exits with `Failed to parse build specification: Unexpected key extensions`,
+   > update to the newest Firebase CLI. That error indicates an outdated CLI version.
 
 ## 2. Enable required Google Cloud APIs
 
@@ -31,7 +34,54 @@ gcloud services enable pubsub.googleapis.com
 The Pub/Sub API is required because scheduled functions are implemented on top
 of Pub/Sub jobs.
 
-## 3. Install and build the Cloud Functions package
+## 3. Configure Firebase Cloud Messaging for the web client
+
+Getting a valid FCM token from the browser requires the project to expose a
+Web Push certificate (VAPID key) and to serve the messaging service worker from
+the app root. Without these pieces, the `getFCMToken()` helper in
+`src/lib/firebase.ts` short-circuits and tokens never reach Firestore.
+
+1. In the Firebase Console, open **Project settings → Cloud Messaging**.
+2. Under **Web configuration**, click **Generate key pair** (or **Manage** if
+   one already exists) to create the VAPID key pair.
+3. Copy the value labelled **Public key** and set it as an environment variable
+   wherever the web app runs:
+
+   ```bash
+   # .env.local for local development and the corresponding production env vars
+   NEXT_PUBLIC_FIREBASE_VAPID_KEY="<paste public key here>"
+   ```
+
+4. Make sure the variable is exported to the build **and** runtime environments
+   for the hosting platform. For example, if deployments run through GitHub
+   Actions, add a repository secret named `NEXT_PUBLIC_FIREBASE_VAPID_KEY` and
+   pass it to the build step in `.github/workflows/firebase-hosting-merge.yml`
+   and `.github/workflows/firebase-hosting-pull-request.yml`:
+
+   ```yaml
+   - run: npm ci && npm run build
+     env:
+       NEXT_PUBLIC_FIREBASE_VAPID_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_VAPID_KEY }}
+   ```
+
+   Simply storing the key as a GitHub secret is not enough—the build must see it
+   when bundling the client code.
+5. Redeploy or restart the web app so that `process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY`
+   is available to the browser bundle. You can confirm the value is wired up by
+   checking the browser console for the log `FCM token retrieved: ✓` after
+   enabling reminders.
+6. Ensure the file `public/firebase-messaging-sw.js` is served from the
+   application root (`https://<your-domain>/firebase-messaging-sw.js`). The
+   service worker must load **before** calling `Notification.requestPermission`
+   so that `navigator.serviceWorker.ready` resolves during token generation.
+7. The site must be served over HTTPS (or `http://localhost` for development)
+   because the Push API is only available on secure origins.
+
+Once the environment variable is set and the service worker is reachable, the
+frontend registers the worker, calls `getToken(...)` with the VAPID key, and
+stores the resulting token in `users/{uid}/notificationSubscriptions/dinner`.
+
+## 4. Install and build the Cloud Functions package
 
 From the repository root:
 
@@ -43,7 +93,7 @@ npm run build
 
 The build step compiles `src/` to `lib/`, which is what Firebase deploys.
 
-## 4. Configure optional notification metadata (optional)
+## 5. Configure optional notification metadata (optional)
 
 If you want to customise the push payload (for example to include a deep link),
 add values to the Cloud Functions config before deploying:
@@ -57,7 +107,7 @@ firebase functions:config:set reminders.notification_body="What did you eat for 
 These keys are not currently required by the code but can be wired in later to
 override the defaults without another deployment.
 
-## 5. Deploy the scheduled function
+## 6. Deploy the scheduled function
 
 Deploy only the new reminder dispatcher:
 
@@ -70,7 +120,7 @@ Accept the prompt. You can confirm the job in the Firebase Console under
 **Functions → Scheduled** or in the Google Cloud Console under **Cloud
 Scheduler**.
 
-## 6. Create the required Firestore index
+## 7. Create the required Firestore index
 
 The function queries the `notificationSubscriptions` collection group using the
 fields `active` and `nextNotificationAt`. Create a composite index for that
@@ -98,20 +148,27 @@ Alternatively, add the following entry to `firestore.indexes.json` and run
 }
 ```
 
-## 7. Verify end-to-end scheduling
+## 8. Verify end-to-end scheduling
 
 1. With the app deployed, enable dinner reminders in the UI. A document similar
    to `users/<uid>/notificationSubscriptions/dinner` should now contain the
    fields `token`, `timezone`, `reminderTime`, and `nextNotificationAt`.
-2. Wait for the scheduled Cloud Function to run (it executes every five
+2. Open the browser console to confirm the app retrieved a token. You should
+   see `Firebase Cloud Messaging supported and initialized` followed by
+   `FCM token retrieved: ✓`. If you instead see `VAPID key not configured for
+   FCM`, revisit step 3 to ensure the env var is present.
+3. Wait for the scheduled Cloud Function to run (it executes every five
    minutes). Check the **Functions → Logs** tab in the Firebase Console for
    entries from `sendDueDinnerReminders`.
-3. When a notification is delivered, the document’s `lastNotificationSentAt`
+4. When a notification is delivered, the document’s `lastNotificationSentAt`
    field updates and `nextNotificationAt` jumps roughly 24 hours ahead in the
    user’s timezone.
-4. If a notification fails because of an invalid FCM token, the document is
+5. If a notification fails because of an invalid FCM token, the document is
    marked `deliveryStatus = "deactivated"`. Clearing or re-enabling reminders in
-   the UI will register a fresh token.
+   the UI will register a fresh token. Repeated failures with
+   `deliveryStatus = "missing-token"` indicate that the frontend never obtained
+   a token—double-check the VAPID key, service worker availability, and
+   notification permissions.
 
 Once these steps are complete, dinner reminders will continue to fire even when
 the web app is closed because Cloud Scheduler triggers the `sendDueDinnerReminders`


### PR DESCRIPTION
## Summary
- document the firebase-tools v13+ requirement and add troubleshooting for the "Unexpected key extensions" deploy error
- call out wiring the NEXT_PUBLIC_FIREBASE_VAPID_KEY secret into the hosting workflows so the Next.js build sees the VAPID key
- bump the reminder deploy workflow to firebase-tools v13 to match the documentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d47e8575d08331acae20df0799f9ff