### PR TITLE
Handle missing Firebase configuration during build

### DIFF
--- a/__tests__/_app.test.tsx
+++ b/__tests__/_app.test.tsx
@@ -1,6 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
-jest.mock('@/lib/firebase', () => ({ auth: {} }));
+const mockEnsureAuthPersistence = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@/lib/firebase', () => ({
+  auth: {},
+  ensureAuthPersistence: mockEnsureAuthPersistence,
+  isFirebaseConfigured: true,
+}));
 
 const mockSignInAnonymously = jest.fn().mockResolvedValue({});
 jest.mock('firebase/auth', () => ({ signInAnonymously: mockSignInAnonymously }));
@@ -11,7 +17,7 @@ function Dummy() {
   return <div data-testid="dummy" />;
 }
 
-test('renders page component', () => {
+test('renders page component', async () => {
   const mockRouter = {
     route: '/',
     pathname: '/',
@@ -28,5 +34,9 @@ test('renders page component', () => {
   
   render(<App Component={Dummy} pageProps={{}} router={mockRouter} />);
   expect(screen.getByTestId('dummy')).toBeInTheDocument();
-  expect(mockSignInAnonymously).toHaveBeenCalled();
+
+  await waitFor(() => {
+    expect(mockEnsureAuthPersistence).toHaveBeenCalled();
+    expect(mockSignInAnonymously).toHaveBeenCalled();
+  });
 });

--- a/__tests__/firebase.test.ts
+++ b/__tests__/firebase.test.ts
@@ -30,13 +30,17 @@ test('initializes firebase with persistence', async () => {
   process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'appid';
   process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID = 'measure';
 
-  const { auth, db } = require('@/lib/firebase');
+  const { auth, db, ensureAuthPersistence, isFirebaseConfigured } = require('@/lib/firebase');
 
   expect(initializeApp).toHaveBeenCalled();
   expect(getAuth).toHaveBeenCalledWith('app');
-  expect(setPersistence).toHaveBeenCalledWith('auth', 'local');
   expect(getFirestore).toHaveBeenCalledWith('app');
   expect(enableIndexedDbPersistence).toHaveBeenCalledWith('db');
   expect(auth).toBe('auth');
   expect(db).toBe('db');
+
+  expect(isFirebaseConfigured).toBe(true);
+
+  await ensureAuthPersistence();
+  expect(setPersistence).toHaveBeenCalledWith('auth', 'local');
 });

--- a/src/lib/notification-manager.ts
+++ b/src/lib/notification-manager.ts
@@ -1,6 +1,6 @@
 // notification-manager.ts - Push notification management for dinner reminders
 
-import { getFCMToken, isFCMSupported, db } from './firebase';
+import { getFCMToken, isFCMSupported, db, isFirebaseConfigured } from './firebase';
 import { ensureAuthenticatedUser } from './firebase-auth';
 import {
   doc,
@@ -211,8 +211,19 @@ class NotificationManager {
     localStorage.removeItem(this.SCHEDULER_KEY);
 
     try {
+      if (!isFirebaseConfigured) {
+        console.warn('Skipping remote reminder persistence because Firebase is not configured.');
+        return;
+      }
+
       const user = await ensureAuthenticatedUser();
-      const reminderRef = doc(db, 'users', user.uid, 'notificationSubscriptions', 'dinner');
+      const database = db;
+      if (!database || !isFirebaseConfigured) {
+        console.warn('Skipping remote reminder persistence because Firebase is not configured.');
+        return;
+      }
+
+      const reminderRef = doc(database, 'users', user.uid, 'notificationSubscriptions', 'dinner');
       const permission = typeof Notification !== 'undefined' ? Notification.permission : 'default';
 
       await setDoc(
@@ -365,6 +376,11 @@ class NotificationManager {
     token?: string | null;
   }): Promise<boolean> {
     try {
+      if (!isFirebaseConfigured) {
+        console.warn('Skipping remote reminder persistence because Firebase is not configured.');
+        return false;
+      }
+
       const ensuredToken = token ?? (await getFCMToken());
       if (!ensuredToken) {
         console.warn('Unable to persist reminder subscription without FCM token');
@@ -372,7 +388,13 @@ class NotificationManager {
       }
 
       const user = await ensureAuthenticatedUser();
-      const reminderRef = doc(db, 'users', user.uid, 'notificationSubscriptions', 'dinner');
+      const database = db;
+      if (!database || !isFirebaseConfigured) {
+        console.warn('Skipping remote reminder persistence because Firebase is not configured.');
+        return false;
+      }
+
+      const reminderRef = doc(database, 'users', user.uid, 'notificationSubscriptions', 'dinner');
       const [hours, minutes] = settings.reminderTime.split(':').map(Number);
       const platform = typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown';
       const permission = typeof Notification !== 'undefined' ? Notification.permission : 'default';
@@ -406,6 +428,11 @@ class NotificationManager {
    */
   static async scheduleTestNotification(): Promise<boolean> {
     try {
+      if (!isFirebaseConfigured) {
+        console.warn('Skipping test reminder persistence because Firebase is not configured.');
+        return false;
+      }
+
       console.log('🔄 Starting test notification scheduling...');
 
       console.log('🔐 Checking authentication...');
@@ -427,7 +454,13 @@ class NotificationManager {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
       console.log('💾 Writing to Firestore...');
-      const reminderRef = doc(db, 'users', user.uid, 'notificationSubscriptions', 'test-dinner');
+      const database = db;
+      if (!database || !isFirebaseConfigured) {
+        console.warn('Skipping test reminder persistence because Firebase is not configured.');
+        return false;
+      }
+
+      const reminderRef = doc(database, 'users', user.uid, 'notificationSubscriptions', 'test-dinner');
       const permission = typeof Notification !== 'undefined' ? Notification.permission : 'default';
       const platform = typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown';
 
@@ -462,8 +495,19 @@ class NotificationManager {
    */
   static async clearTestNotification(): Promise<void> {
     try {
+      if (!isFirebaseConfigured) {
+        console.warn('Skipping reminder disable because Firebase is not configured.');
+        return;
+      }
+
       const user = await ensureAuthenticatedUser();
-      const reminderRef = doc(db, 'users', user.uid, 'notificationSubscriptions', 'test-dinner');
+      const database = db;
+      if (!database || !isFirebaseConfigured) {
+        console.warn('Skipping reminder disable because Firebase is not configured.');
+        return;
+      }
+
+      const reminderRef = doc(database, 'users', user.uid, 'notificationSubscriptions', 'test-dinner');
 
       await setDoc(
         reminderRef,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import { useEffect } from "react";
-import { auth } from "@/lib/firebase";
+import { auth, ensureAuthPersistence, isFirebaseConfigured } from "@/lib/firebase";
 import { signInAnonymously } from "firebase/auth";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { registerServiceWorker } from "@/lib/pwa-utils";
@@ -9,7 +9,16 @@ import { registerServiceWorker } from "@/lib/pwa-utils";
 export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
     // Initialize Firebase auth
-    signInAnonymously(auth).catch(() => {});
+    if (!isFirebaseConfigured || !auth) {
+      console.warn("Firebase auth is not configured. Skipping anonymous sign-in.");
+    } else {
+      const firebaseAuth = auth;
+      ensureAuthPersistence()
+        .then(() => signInAnonymously(firebaseAuth))
+        .catch((error) => {
+          console.warn("Firebase auth initialization skipped:", error);
+        });
+    }
 
     // Register service worker for PWA functionality
     registerServiceWorker().then((registration) => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -69,10 +69,15 @@ export default function Meals() {
   }
 
   async function syncPendingMeals() {
+    const database = db;
+    if (!database) {
+      return;
+    }
+
     const pending = await getPendingMeals();
     for (const m of pending) {
       try {
-        const docRef = await addDoc(collection(db, "meals"), {
+        const docRef = await addDoc(collection(database, "meals"), {
           mealName: m.mealName,
           date: m.date,
           uid: m.uid,
@@ -111,7 +116,7 @@ export default function Meals() {
     setMessage(null);
 
     // Check rate limiting
-    const rateLimitCheck = checkFormSubmissionLimit(auth.currentUser?.uid);
+    const rateLimitCheck = checkFormSubmissionLimit(auth?.currentUser?.uid);
     if (!rateLimitCheck.allowed) {
       setErrors([`Too many submissions. Please wait ${rateLimitCheck.retryAfter} seconds before trying again.`]);
       return;
@@ -129,7 +134,7 @@ export default function Meals() {
         id: Date.now().toString(),
         mealName: validation.data.mealName,
         date: Timestamp.fromDate(new Date(validation.data.date + 'T00:00:00')),
-        uid: auth.currentUser?.uid,
+        uid: auth?.currentUser?.uid,
         pending: true,
       };
       


### PR DESCRIPTION
## Summary
- add configuration detection in the Firebase bootstrap so the SDK is skipped when required environment variables are missing
- guard application startup, Firestore backup, and notification scheduling flows so they no longer access Firebase services when configuration is absent
- update unit tests to reflect the new initialization and guard behaviour

## Testing
- `CI=1 npm run build`
- `npm run type-check`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d4914a31608331819030792bcb14f6