### PR TITLE
Update Firebase CLI for reminder deployment workflow

### DIFF
--- a/.github/workflows/firebase-reminder-deploy.yml
+++ b/.github/workflows/firebase-reminder-deploy.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       - name: Install Firebase CLI
-        run: npm install --global firebase-tools@12
+        run: npm install --global firebase-tools
 
       - name: Install function dependencies
         working-directory: functions


### PR DESCRIPTION
## Summary
- install the latest firebase-tools CLI in the reminder deployment workflow to support the extensions manifest

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5067e737c833183c1cc600ac1da5b