### PR TITLE
Align Firebase env handling with client bundle

### DIFF
--- a/__tests__/firebase.test.ts
+++ b/__tests__/firebase.test.ts
@@ -17,20 +17,35 @@ jest.mock('firebase/firestore', () => ({
   enableIndexedDbPersistence: jest.fn(() => Promise.resolve()),
 }));
 
+const originalEnv = process.env;
+
 afterEach(() => {
+  process.env = originalEnv;
   jest.resetModules();
+  jest.clearAllMocks();
 });
 
 test('initializes firebase with persistence', async () => {
-  process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'key';
-  process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'domain';
-  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'project';
-  process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'bucket';
-  process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'sender';
-  process.env.NEXT_PUBLIC_FIREBASE_APP_ID = 'appid';
-  process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID = 'measure';
+  const envCopy = { ...originalEnv } as NodeJS.ProcessEnv;
+  envCopy.NEXT_PUBLIC_FIREBASE_API_KEY = 'key';
+  envCopy.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'domain';
+  envCopy.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'project';
+  envCopy.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'bucket';
+  envCopy.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID = 'sender';
+  envCopy.NEXT_PUBLIC_FIREBASE_APP_ID = 'appid';
+  envCopy.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID = 'measure';
+  envCopy.NEXT_PUBLIC_FIREBASE_VAPID_KEY = 'vapid';
 
-  const { auth, db, ensureAuthPersistence, isFirebaseConfigured } = require('@/lib/firebase');
+  process.env = envCopy;
+
+  const {
+    auth,
+    db,
+    ensureAuthPersistence,
+    isFirebaseConfigured,
+  } = require('@/lib/firebase');
+
+  expect(isFirebaseConfigured).toBe(true);
 
   expect(initializeApp).toHaveBeenCalled();
   expect(getAuth).toHaveBeenCalledWith('app');
@@ -39,8 +54,26 @@ test('initializes firebase with persistence', async () => {
   expect(auth).toBe('auth');
   expect(db).toBe('db');
 
-  expect(isFirebaseConfigured).toBe(true);
-
   await ensureAuthPersistence();
   expect(setPersistence).toHaveBeenCalledWith('auth', 'local');
+});
+
+test('isFirebaseConfigured remains true with populated client env map', () => {
+  jest.isolateModules(() => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_FIREBASE_API_KEY: 'key',
+      NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: 'domain',
+      NEXT_PUBLIC_FIREBASE_PROJECT_ID: 'project',
+      NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: 'bucket',
+      NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: 'sender',
+      NEXT_PUBLIC_FIREBASE_APP_ID: 'appid',
+      NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: 'measure',
+      NEXT_PUBLIC_FIREBASE_VAPID_KEY: 'vapid',
+    } as NodeJS.ProcessEnv;
+
+    const { isFirebaseConfigured } = require('@/lib/firebase');
+
+    expect(isFirebaseConfigured).toBe(true);
+  });
 });

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -17,6 +17,27 @@ import {
   type Messaging,
 } from "firebase/messaging";
 
+const firebaseEnv = {
+  NEXT_PUBLIC_FIREBASE_API_KEY:
+    process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "",
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:
+    process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "",
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID:
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "",
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:
+    process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "",
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:
+    process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "",
+  NEXT_PUBLIC_FIREBASE_APP_ID:
+    process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "",
+  NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID:
+    process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID ?? "",
+  NEXT_PUBLIC_FIREBASE_VAPID_KEY:
+    process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY ?? "",
+} as const;
+
+type FirebaseEnv = typeof firebaseEnv;
+
 const requiredEnvVars = [
   "NEXT_PUBLIC_FIREBASE_API_KEY",
   "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
@@ -26,21 +47,33 @@ const requiredEnvVars = [
   "NEXT_PUBLIC_FIREBASE_APP_ID",
 ] as const;
 
-const missingEnvVars = requiredEnvVars.filter(
-  (key) => !process.env[key],
-);
+type RequiredEnvKey = (typeof requiredEnvVars)[number];
+
+const missingEnvVars = (
+  Object.entries(firebaseEnv) as [keyof FirebaseEnv, string][]
+)
+  .filter(
+    ([key, value]) =>
+      requiredEnvVars.includes(key as RequiredEnvKey) && value.length === 0,
+  )
+  .map(([key]) => key as RequiredEnvKey);
 
 export const isFirebaseConfigured = missingEnvVars.length === 0;
 
 const firebaseConfig = isFirebaseConfigured
   ? {
-      apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
-      authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
-      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
-      storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
-      messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-      appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
-      measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID ?? undefined,
+      apiKey: firebaseEnv.NEXT_PUBLIC_FIREBASE_API_KEY,
+      authDomain: firebaseEnv.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+      projectId: firebaseEnv.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+      storageBucket: firebaseEnv.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+      messagingSenderId: firebaseEnv.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+      appId: firebaseEnv.NEXT_PUBLIC_FIREBASE_APP_ID,
+      ...(firebaseEnv.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
+        ? {
+            measurementId:
+              firebaseEnv.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+          }
+        : {}),
     }
   : null;
 
@@ -105,7 +138,7 @@ export async function getFCMToken(): Promise<string | null> {
 
   try {
     // You'll need to add your VAPID key from Firebase Console
-    const vapidKey = process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY;
+    const vapidKey = firebaseEnv.NEXT_PUBLIC_FIREBASE_VAPID_KEY;
     if (!vapidKey) {
       console.warn("VAPID key not configured for FCM");
       return null;


### PR DESCRIPTION
## Summary
- capture Firebase public variables in a firebaseEnv map built from direct environment property access
- derive the missing-env check and firebaseConfig from firebaseEnv to keep a single source of truth for client builds
- extend the firebase test suite to cover the compiled env map scenario and keep isFirebaseConfigured true when values exist

## Testing
- npm test -- __tests__/firebase.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d74d9b35048331848a8a17e96c7235