### PR TITLE
Fix confirm dialog cleanup and refresh handling

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -21,15 +21,26 @@ export default function ConfirmDialog({
   onCancel,
   variant = 'default'
 }: ConfirmDialogProps) {
+  const previousOverflowRef = useRef<string | null>(null);
+
   useEffect(() => {
+    const { style } = document.body;
+
     if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
+      if (previousOverflowRef.current === null) {
+        previousOverflowRef.current = style.overflow;
+      }
+      style.overflow = 'hidden';
+    } else if (previousOverflowRef.current !== null) {
+      style.overflow = previousOverflowRef.current;
+      previousOverflowRef.current = null;
     }
-    
+
     return () => {
-      document.body.style.overflow = 'unset';
+      if (previousOverflowRef.current !== null) {
+        style.overflow = previousOverflowRef.current;
+        previousOverflowRef.current = null;
+      }
     };
   }, [isOpen]);
 

--- a/src/components/HistoryAccordion.tsx
+++ b/src/components/HistoryAccordion.tsx
@@ -21,9 +21,11 @@ export default function HistoryAccordion({ isOpen, onToggle, refreshTrigger }: H
 
   // Refresh meals when refreshTrigger changes
   useEffect(() => {
-    if (refreshTrigger) {
-      loadMeals();
+    if (refreshTrigger === undefined || refreshTrigger === null) {
+      return;
     }
+
+    loadMeals();
   }, [refreshTrigger, loadMeals]);
 
   const startEdit = useCallback((meal: Meal) => {

--- a/src/hooks/useConfirmDialog.ts
+++ b/src/hooks/useConfirmDialog.ts
@@ -31,8 +31,11 @@ export function useConfirmDialog() {
   };
 
   const confirmAndClose = () => {
-    dialogState.onConfirm();
-    hideDialog();
+    try {
+      dialogState.onConfirm();
+    } finally {
+      hideDialog();
+    }
   };
 
   return {


### PR DESCRIPTION
## Summary
- ensure the history accordion reloads when the refresh trigger is zero
- preserve the previous body overflow style when toggling the confirm dialog
- always close the confirm dialog even if the confirm handler throws

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d772bc1748833195f55ee520175242