### PR TITLE
Restore data management styling

### DIFF
--- a/src/components/data-management/CloudBackup.tsx
+++ b/src/components/data-management/CloudBackup.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { backupMealsToCloud, getCloudBackupStatus, type CloudBackupStatus } from '@/lib/firestore-backup';
-import { getAllMeals } from '@/lib/offline-storage';
 import type { MessageState } from './types';
 
 interface CloudBackupProps {
@@ -70,51 +69,58 @@ export default function CloudBackup({ onMessage }: CloudBackupProps) {
     }
   };
 
-  return (
-    <div className="backup-section">
-      <h3>Cloud Backup</h3>
-      <p>Securely backup your data to the cloud for access across devices.</p>
+  const statusVariant =
+    !cloudBackupStatus?.isAuthenticated || cloudBackupStatus?.syncNeeded ? 'warning' : 'active';
 
-      {cloudBackupStatus && (
-        <div className="backup-status">
-          <div className="status-grid">
-            <div className="status-item">
-              <span className="status-label">Status:</span>
-              <span className={`status-value ${cloudBackupStatus.isAuthenticated ? 'authenticated' : 'not-authenticated'}`}>
-                {cloudBackupStatus.isAuthenticated ? '✅ Connected' : '❌ Not Connected'}
+  return (
+    <>
+      <div className="status-header">
+        <h2>Cloud Backup</h2>
+        <div className="status-indicator">
+          <div className={`status-dot ${statusVariant}`} />
+          <span className={`status-text ${statusVariant}`}>
+            {!cloudBackupStatus?.isAuthenticated
+              ? 'Not Connected'
+              : cloudBackupStatus?.syncNeeded
+              ? 'Sync Needed'
+              : 'Up to Date'}
+          </span>
+        </div>
+      </div>
+
+      {cloudBackupStatus ? (
+        <div className="backup-info-compact">
+          <div className="backup-stats">
+            <div className="backup-stat">
+              <span>📊</span>
+              <span>
+                <strong>Cloud Meals:</strong> {cloudBackupStatus.cloudMealCount}
               </span>
             </div>
-            {cloudBackupStatus.isAuthenticated && (
-              <>
-                <div className="status-item">
-                  <span className="status-label">Cloud Meals:</span>
-                  <span className="status-value">{cloudBackupStatus.cloudMealCount}</span>
-                </div>
-                <div className="status-item">
-                  <span className="status-label">Last Backup:</span>
-                  <span className="status-value">{formatTimeAgo(cloudBackupStatus.lastCloudBackup)}</span>
-                </div>
-                <div className="status-item">
-                  <span className="status-label">Sync Status:</span>
-                  <span className={`status-value ${cloudBackupStatus.syncNeeded ? 'sync-needed' : 'up-to-date'}`}>
-                    {cloudBackupStatus.syncNeeded ? '⚠️ Sync Needed' : '✅ Up to Date'}
-                  </span>
-                </div>
-              </>
-            )}
+            <div className="backup-stat">
+              <span>⏰</span>
+              <span>
+                <strong>Last Backup:</strong> {formatTimeAgo(cloudBackupStatus.lastCloudBackup)}
+              </span>
+            </div>
+            <div className="backup-stat">
+              <span>☁️</span>
+              <span>
+                <strong>Status:</strong> {cloudBackupStatus.isAuthenticated ? '✅ Connected' : '❌ Not Connected'}
+              </span>
+            </div>
           </div>
+          <button
+            className="backup-button compact"
+            onClick={handleBackupNow}
+            disabled={exporting}
+          >
+            {exporting ? 'Backing Up...' : 'Backup Now'}
+          </button>
         </div>
+      ) : (
+        <div className="loading">Loading cloud backup status...</div>
       )}
-
-      <div className="backup-actions">
-        <button
-          onClick={handleBackupNow}
-          disabled={exporting}
-          className="backup-button primary"
-        >
-          {exporting ? 'Backing up...' : 'Backup Now'}
-        </button>
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/components/data-management/DataExport.tsx
+++ b/src/components/data-management/DataExport.tsx
@@ -74,23 +74,26 @@ export default function DataExport({ onMessage }: DataExportProps) {
   };
 
   return (
-    <div className="export-section">
-      <h3>Export All Data (JSON)</h3>
-      <p>Download all your dishes, settings, and metadata as a JSON file for backup or migration.</p>
+    <div>
+      <div className="export-controls">
+        <p className="export-description">
+          Export all your meal data as a JSON file for backup or transfer to another device.
+        </p>
 
-      <div className="export-actions">
         <button
+          className="export-button primary"
           onClick={handleExport}
           disabled={exporting}
-          className="export-button primary"
         >
           {exporting ? 'Exporting...' : 'Export All Data (JSON)'}
         </button>
-      </div>
 
-      <div className="export-info">
-        <p className="info-text">
-          💡 <strong>Tip:</strong> Regular exports help protect your data. The exported file can be re-imported on any device.
+        <p className="export-note">
+          <strong>Save Options:</strong> Modern browsers (Chrome, Edge) will show a "Save As" dialog to choose your save location.
+          For Google Drive, save to your local Google Drive folder or use the Google Drive web interface to upload the file.
+        </p>
+        <p className="export-details">
+          The exported file will include all meals, settings, and metadata in JSON format.
         </p>
       </div>
     </div>

--- a/src/components/data-management/DataManagement.tsx
+++ b/src/components/data-management/DataManagement.tsx
@@ -27,7 +27,7 @@ export default function DataManagement() {
   return (
     <>
       <Navigation currentPage="account" />
-      <main className="main-container">
+      <main className="container">
         <h1>Data Management</h1>
 
         {/* Install Prompt */}
@@ -35,8 +35,8 @@ export default function DataManagement() {
 
         {/* Global Messages */}
         {message && (
-          <div className={`message ${message.type}`}>
-            {message.text}
+          <div className={`message-card ${message.type}`}>
+            <p>{message.text}</p>
             <button
               onClick={() => setMessage(null)}
               className="message-close"
@@ -47,19 +47,23 @@ export default function DataManagement() {
           </div>
         )}
 
+        {/* Notification Settings */}
+        <section className="data-section">
+          <NotificationSettings onMessage={setMessage} />
+        </section>
+
         {/* Cloud Backup Section */}
         <section className="data-section">
           <CloudBackup onMessage={setMessage} />
         </section>
 
         {/* Local Data Management */}
-        <section className="data-section">
-          <div className="status-header">
+        <section className="data-section enhanced-tabs">
+          <div className="tab-header">
             <h2>📁 Local Data Management</h2>
-            <div className="status-indicator">
-              <div className="status-dot active" />
-              <span className="status-text active">Ready</span>
-            </div>
+            <p className="tab-description">
+              Export your meal data for backup, import saved files, and verify data integrity.
+            </p>
           </div>
 
           {/* Tab Navigation */}
@@ -86,8 +90,8 @@ export default function DataManagement() {
 
           {/* Import-specific messages */}
           {activeTab === 'import' && importMessage && (
-            <div className={`message ${importMessage.type}`}>
-              {importMessage.text}
+            <div className={`message-card ${importMessage.type}`} style={{ margin: '16px 0' }}>
+              <p>{importMessage.text}</p>
               <button
                 onClick={() => setImportMessage(null)}
                 className="message-close"
@@ -104,11 +108,6 @@ export default function DataManagement() {
             {activeTab === 'import' && <DataImport onMessage={setImportMessage} />}
             {activeTab === 'verification' && <DataValidation />}
           </div>
-        </section>
-
-        {/* Notification Settings */}
-        <section className="data-section">
-          <NotificationSettings onMessage={setMessage} />
         </section>
 
         {/* PWA Status */}

--- a/src/components/data-management/DataValidation.tsx
+++ b/src/components/data-management/DataValidation.tsx
@@ -26,29 +26,31 @@ export default function DataValidation() {
   };
 
   if (validating) {
-    return (
-      <div className="validation-loading">
-        <p>Validating data integrity...</p>
-      </div>
-    );
+    return <div className="loading">Validating data integrity...</div>;
   }
 
   if (!validationResult) {
     return (
-      <div className="validation-error">
-        <p>Unable to load validation results.</p>
-        <button onClick={handleRevalidate} className="retry-button">
-          Retry Validation
-        </button>
-      </div>
+      <>
+        <div className="message-card error">
+          <p>Unable to load validation results.</p>
+        </div>
+        <div className="action-group">
+          <button onClick={handleRevalidate} className="primary-button">
+            Retry Validation
+          </button>
+        </div>
+      </>
     );
   }
 
-  return (
-    <div className="validation-section">
-      <h3>Data Verification</h3>
-      <p>Check the integrity and health of your stored data.</p>
+  const statusPrefix = validationResult.valid ? 'All systems operational.' : 'Issues detected in your data.';
+  const statusSuffix = validationResult.valid
+    ? 'Your training data is secure and backed up regularly.'
+    : 'Review the issues below and consider running a data repair.';
 
+  return (
+    <div>
       <div className="verification-grid">
         <div className="score-circle">
           <span className="score">{validationResult.stats.dataIntegrityScore}</span>
@@ -58,9 +60,7 @@ export default function DataValidation() {
         <div className="verification-stats">
           <div className="verification-stat">
             <span className="verification-label">Total Sessions</span>
-            <span className="verification-value">
-              {validationResult.stats.totalMeals}
-            </span>
+            <span className="verification-value">{validationResult.stats.totalMeals}</span>
           </div>
           <div className="verification-stat">
             <span className="verification-label">Issues Found</span>
@@ -76,33 +76,25 @@ export default function DataValidation() {
           </div>
           <div className="verification-stat">
             <span className="verification-label">Last Check</span>
-            <span className="verification-value">
-              Just now
-            </span>
+            <span className="verification-value">Just now</span>
           </div>
         </div>
       </div>
 
       <div className="verification-status">
         <p>
-          <strong>
-            {validationResult.valid
-              ? 'All systems operational.'
-              : 'Issues detected in your data.'
-            }
-          </strong>{' '}
-          {validationResult.valid
-            ? 'Your training data is secure and backed up regularly.'
-            : 'Review the issues below and consider running a data repair.'}
+          <strong>{statusPrefix}</strong> {statusSuffix}
         </p>
       </div>
 
       {validationResult.errors.length > 0 && (
-        <div className="validation-errors">
-          <h4>Issues Found:</h4>
+        <div className="message-card error">
+          <p>
+            <strong>Issues Found:</strong>
+          </p>
           <ul>
             {validationResult.errors.map((error, index) => (
-              <li key={index} className={`error-item ${error.type}`}>
+              <li key={index}>
                 <strong>{error.type}:</strong> {error.message}
               </li>
             ))}
@@ -111,11 +103,13 @@ export default function DataValidation() {
       )}
 
       {validationResult.warnings.length > 0 && (
-        <div className="validation-warnings">
-          <h4>Warnings:</h4>
+        <div className="message-card info">
+          <p>
+            <strong>Warnings:</strong>
+          </p>
           <ul>
             {validationResult.warnings.map((warning, index) => (
-              <li key={index} className="warning-item">
+              <li key={index}>
                 <strong>{warning.type}:</strong> {warning.message}
               </li>
             ))}
@@ -123,8 +117,8 @@ export default function DataValidation() {
         </div>
       )}
 
-      <div className="validation-actions">
-        <button onClick={handleRevalidate} className="revalidate-button secondary">
+      <div className="action-group">
+        <button onClick={handleRevalidate} className="secondary-button">
           Run Validation Again
         </button>
       </div>


### PR DESCRIPTION
## Summary
- restore the account data management layout to use the existing global styles and message cards
- update the cloud backup, export/import, validation, and notification sections to reuse the legacy class names while keeping the new component structure
- ensure the restored markup still satisfies the account page tests and button labels

## Testing
- npm run lint *(fails: existing no-undef error in next.config.mjs and legacy @typescript-eslint warnings)*
- npm test -- account

------
https://chatgpt.com/codex/tasks/task_e_68d8ccae217c833187a2c3f60df862fb