### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2025-09-28
+
+### Added
+- **Data Management Dashboard**: Unified status headers, compact stats, and drag-and-drop importing for the Cloud Backup and Import panels make the settings area easier to scan and use.
+- **Notification Testing Tools**: Added UI controls to schedule a server-driven dinner reminder test and clear it without leaving the app.
+
+### Changed
+- **Import Pipeline Hardening**: Tightened type guards, normalized metadata, and improved conflict summaries when restoring meals from JSON, CSV, or backup exports.
+- **Notification Controls**: Reworked toggle logic to better surface browser support, permission state, and reminder timing in one place.
+
+### Fixed
+- **Reminder Lifecycle**: Ensured disabling reminders clears scheduled jobs and surfaces clearer feedback when browser permissions block activation.
+- **Modal Cleanup**: Confirm dialogs now always restore the document scroll state even if confirm handlers throw.
+
 ## [0.4.4] - 2025-09-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dish-diary",
-  "version": "0.4.0",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dish-diary",
-      "version": "0.4.0",
+      "version": "0.4.5",
       "dependencies": {
         "dompurify": "^3.2.6",
         "firebase": "^12.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dish-diary",
-  "version": "0.4.3",
+  "version": "0.4.5",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the project version to 0.4.5
- document recent notification and data management improvements in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8e1af511883319b33db5644dc8e8e