### PR TITLE
Dishes page: persistent sort dropdown, oldest-first default, compact layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-05-22
+
+### Changed
+- **Dishes Default Sort**: Sort order on the Dishes page now defaults to "Last made: oldest first" so meal planning surfaces dishes you haven't had recently without any extra interaction.
+- **Always-Visible Sort Dropdown**: The sort control is moved out of the collapsible filter panel into a persistent toolbar row at the top of the page, accessible without opening the filters.
+- **Compact Dish List**: Reduced table cell padding and widened the Dish name column (30% → 42%) while narrowing Last Made (15% → 11%) and Tags (45% → 37%), fitting more dishes on screen at once.
+
+### Technical
+- Updated visible app/export version references to `0.9.2`.
+
 ## [0.9.1] - 2026-04-06
 
 ### Added

--- a/__tests__/ideas.test.tsx
+++ b/__tests__/ideas.test.tsx
@@ -51,8 +51,8 @@ test('renders unique meals with counts', async () => {
 
   const rows = screen.getAllByRole('row').slice(1); // skip header
   expect(rows).toHaveLength(2);
-  expect(rows[0]).toHaveTextContent('Chicken Stir Fry');
-  expect(rows[1]).toHaveTextContent('Pasta Carbonara');
+  expect(rows[0]).toHaveTextContent('Pasta Carbonara');
+  expect(rows[1]).toHaveTextContent('Chicken Stir Fry');
 
   // Check that info buttons are present instead of count columns
   expect(screen.getAllByTitle('Show details')).toHaveLength(2);
@@ -96,25 +96,24 @@ test('supports sorting dishes by oldest first and alphabetically', async () => {
       .slice(1)
       .map((row) => within(row).getAllByRole('cell')[0]?.textContent);
 
+  // Default is oldest-first
   expect(getDishOrder()).toEqual([
-    'Chicken Stir Fry',
-    'Apple Curry',
     'Beef Tacos',
+    'Apple Curry',
+    'Chicken Stir Fry',
   ]);
 
-  fireEvent.click(screen.getByRole('button', { name: /filter/i }));
-
-  fireEvent.change(screen.getByLabelText('Sort dishes'), {
-    target: { value: 'oldest' },
+  fireEvent.change(screen.getByLabelText('Sort:'), {
+    target: { value: 'newest' },
   });
 
   expect(getDishOrder()).toEqual([
-    'Beef Tacos',
-    'Apple Curry',
     'Chicken Stir Fry',
+    'Apple Curry',
+    'Beef Tacos',
   ]);
 
-  fireEvent.change(screen.getByLabelText('Sort dishes'), {
+  fireEvent.change(screen.getByLabelText('Sort:'), {
     target: { value: 'alphabetical' },
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dish-diary",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/lib/export-manager.ts
+++ b/src/lib/export-manager.ts
@@ -65,7 +65,7 @@ export interface SerializableMeal {
 }
 
 export class ExportManager {
-  private static readonly VERSION = '0.9.1';
+  private static readonly VERSION = '0.9.2';
   private static readonly SOURCE = 'dish-diary';
 
   /**

--- a/src/pages/dishes.tsx
+++ b/src/pages/dishes.tsx
@@ -13,7 +13,7 @@ export default function Ideas() {
   const [showHidden, setShowHidden] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [dateFilter, setDateFilter] = useState<DateFilterOption>("any");
-  const [sortOrder, setSortOrder] = useState<SortOption>("newest");
+  const [sortOrder, setSortOrder] = useState<SortOption>("oldest");
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
   const [tagFilterMode, setTagFilterMode] = useState<TagFilterMode>("OR");
   const { dialogProps, showDialog } = useConfirmDialog();
@@ -169,6 +169,22 @@ export default function Ideas() {
         </button>
       </div>
 
+      <div className="dishes-toolbar">
+        <div className="toolbar-sort">
+          <label htmlFor="dish-sort-order">Sort:</label>
+          <select
+            id="dish-sort-order"
+            className="sort-select-inline"
+            value={sortOrder}
+            onChange={(e) => setSortOrder(e.target.value as SortOption)}
+          >
+            <option value="newest">Last made: newest first</option>
+            <option value="oldest">Last made: oldest first</option>
+            <option value="alphabetical">Name: A–Z</option>
+          </select>
+        </div>
+      </div>
+
       {showFilters && (
         <div className="ideas-filters">
           <h3 className="filter-section-title">Filters</h3>
@@ -218,22 +234,6 @@ export default function Ideas() {
               </button>
             </div>
           )}
-
-          <div className="filter-section">
-            <div className="form-group-compact">
-              <label htmlFor="dish-sort-order">Sort dishes</label>
-              <select
-                id="dish-sort-order"
-                className="form-select-compact"
-                value={sortOrder}
-                onChange={(e) => setSortOrder(e.target.value as SortOption)}
-              >
-                <option value="newest">Last made: newest first</option>
-                <option value="oldest">Last made: oldest first</option>
-                <option value="alphabetical">Name: A-Z</option>
-              </select>
-            </div>
-          </div>
 
           {/* Tag Filter */}
           {allUniqueTags.length > 0 && (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -214,7 +214,7 @@ export default function Meals() {
       />
 
       <div className="version-indicator">
-        v0.9.1
+        v0.9.2
       </div>
     </main>
     </>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -164,7 +164,7 @@ h1 {
 .ideas-table th,
 .ideas-table td {
   text-align: left;
-  padding: 1rem;
+  padding: 0.5rem 0.75rem;
 }
 
 .ideas-table th {
@@ -588,6 +588,32 @@ h1 {
 .filter-button:hover {
   background: #e5e7eb;
   border-color: #9ca3af;
+}
+
+/* Dishes Toolbar (always-visible sort row) */
+.dishes-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.toolbar-sort {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  color: #374151;
+}
+
+.sort-select-inline {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  background: white;
+  cursor: pointer;
 }
 
 /* Ideas Filter Toggle */
@@ -3108,15 +3134,15 @@ h1 {
 
 /* Column width adjustments */
 .ideas-table th:nth-child(1) { /* Dish name */
-  width: 30%;
+  width: 42%;
 }
 
 .ideas-table th:nth-child(2) { /* Last Made */
-  width: 15%;
+  width: 11%;
 }
 
 .ideas-table th:nth-child(3) { /* Tags */
-  width: 45%;
+  width: 37%;
 }
 
 .ideas-table th:nth-child(4) { /* Info */


### PR DESCRIPTION
## Summary

- **Default sort changed to oldest-first** — the Dishes page now loads sorted by least-recently-made, which is more useful for meal planning (surfaces dishes you haven't had in a while)
- **Sort always visible** — the sort dropdown is moved out of the collapsible filter panel into a persistent toolbar row at the top of the page, so it's accessible without clicking the 🔍 Filter button
- **Compact table layout** — cell padding reduced and the Dish name column widened (30% → 42%) while Last Made (15% → 11%) and Tags (45% → 37%) are narrowed, fitting more dishes on screen at once

## What changed

| File | Change |
|------|--------|
| `src/pages/dishes.tsx` | Default sort state `"newest"` → `"oldest"`; new `.dishes-toolbar` row with always-visible sort select; sort block removed from filter panel |
| `src/styles/globals.css` | Table cell padding `1rem` → `0.5rem 0.75rem`; column widths updated; new `.dishes-toolbar` / `.toolbar-sort` / `.sort-select-inline` CSS |
| `__tests__/ideas.test.tsx` | Updated expected row order to match new oldest-first default; updated label selector from `"Sort dishes"` to `"Sort:"` |

## Reviewer notes

- The 🔍 Filter button still controls the collapsible panel for date / tag / show-hidden filters — only the sort was moved out
- All 128 tests pass (pre-commit hook ran full suite)