### PR TITLE
Fix 9 code-review findings: data loss, sync correctness, auth, stability

### DIFF
--- a/__tests__/cloud-sync.test.ts
+++ b/__tests__/cloud-sync.test.ts
@@ -190,7 +190,7 @@ describe('cloud-sync', () => {
     expect(mockUpsertMealFromCloud).toHaveBeenCalled();
     expect(mockSaveMeal).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'local-only', uid: 'uid-1', pending: true }),
-      { skipSyncQueue: false }
+      { skipSyncQueue: false, preserveTimestamp: true }
     );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dish-diary",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dish-diary",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@tanstack/react-query": "^5.100.6",
         "dompurify": "^3.4.2",

--- a/src/components/data-management/CloudSyncPanel.tsx
+++ b/src/components/data-management/CloudSyncPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   createAccountWithEmailPassword,
   getSyncStatus,
@@ -33,6 +33,11 @@ export default function CloudSyncPanel({ onMessage }: CloudSyncPanelProps) {
   const [isAuthLoading, setIsAuthLoading] = useState(false);
   const [isManualSyncing, setIsManualSyncing] = useState(false);
 
+  // Keep a stable ref so the polling effect doesn't re-register its interval
+  // every time the parent passes a new onMessage function reference.
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
+
   useEffect(() => {
     let active = true;
 
@@ -44,7 +49,7 @@ export default function CloudSyncPanel({ onMessage }: CloudSyncPanelProps) {
         }
       } catch (error) {
         if (active) {
-          onMessage({
+          onMessageRef.current({
             type: 'error',
             text: `Unable to load sync status: ${error instanceof Error ? error.message : 'Unknown error'}`
           });
@@ -61,7 +66,7 @@ export default function CloudSyncPanel({ onMessage }: CloudSyncPanelProps) {
       active = false;
       window.clearInterval(interval);
     };
-  }, [onMessage]);
+  }, []);
 
   const handleSignIn = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/components/ideas/TagManagementSection.tsx
+++ b/src/components/ideas/TagManagementSection.tsx
@@ -42,7 +42,9 @@ export const TagManagementSection = React.memo<TagManagementSectionProps>(({
     const trimmedTag = newTagInput.trim();
     if (trimmedTag && !tagStrings.includes(trimmedTag)) {
       const newTags = [...tagStrings, trimmedTag];
-      onTagsUpdated?.(idea.mealName, newTags);
+      Promise.resolve(onTagsUpdated?.(idea.mealName, newTags)).catch(err =>
+        console.error('Tag update failed:', err)
+      );
     }
     setNewTagInput('');
     setShowTagInput(false);
@@ -57,7 +59,9 @@ export const TagManagementSection = React.memo<TagManagementSectionProps>(({
 
   const handleRemoveTag = useCallback((tagToRemove: string) => {
     const newTags = tagStrings.filter(tag => tag !== tagToRemove);
-    onTagsUpdated?.(idea.mealName, newTags);
+    Promise.resolve(onTagsUpdated?.(idea.mealName, newTags)).catch(err =>
+      console.error('Tag update failed:', err)
+    );
   }, [tagStrings, idea.mealName, onTagsUpdated]);
 
   const selectSuggestion = useCallback((suggestion: string) => {
@@ -66,7 +70,9 @@ export const TagManagementSection = React.memo<TagManagementSectionProps>(({
     // Auto-add the selected suggestion
     if (!tagStrings.includes(suggestion)) {
       const newTags = [...tagStrings, suggestion];
-      onTagsUpdated?.(idea.mealName, newTags);
+      Promise.resolve(onTagsUpdated?.(idea.mealName, newTags)).catch(err =>
+        console.error('Tag update failed:', err)
+      );
     }
     setNewTagInput('');
     setShowTagInput(false);

--- a/src/lib/cloud-sync.ts
+++ b/src/lib/cloud-sync.ts
@@ -164,7 +164,7 @@ async function initialPullAndMerge(uid: string): Promise<number> {
           syncState: 'pending',
           updatedAtMs: localMeal.updatedAtMs ?? localFresh
         },
-        { skipSyncQueue: false }
+        { skipSyncQueue: false, preserveTimestamp: true }
       );
     }
   }
@@ -304,8 +304,6 @@ async function runSignedInSync(uid: string): Promise<SyncNowResult> {
     const flushResult = await flushSyncQueue(uid);
     result.pushed += flushResult.pushed;
     result.errors.push(...flushResult.errors);
-
-    result.pulled += await initialPullAndMerge(uid);
 
     if (result.errors.length > 0) {
       lastError = result.errors.join(' | ');

--- a/src/lib/firebase-auth.ts
+++ b/src/lib/firebase-auth.ts
@@ -16,7 +16,9 @@ if (typeof window !== "undefined" && auth && typeof auth.onAuthStateChanged === 
 }
 
 export function getCurrentUser(): User | null {
-  return currentUser;
+  // Prefer the SDK's own currentUser which is updated synchronously on sign-in,
+  // rather than the module-level copy which waits for the onAuthStateChanged callback.
+  return auth?.currentUser ?? currentUser;
 }
 
 export async function ensureAuthenticatedUser(): Promise<User> {

--- a/src/lib/firestore-backup.ts
+++ b/src/lib/firestore-backup.ts
@@ -184,9 +184,16 @@ export async function getCloudBackupStatus(): Promise<CloudBackupStatus> {
     const countSnapshot = await getCountFromServer(mealsCollectionRef);
     status.cloudMealCount = countSnapshot.data().count;
 
-    // Check if local meals need syncing (use actual meal count from main database)
+    // Check if local meals need syncing: count differs, or any meal was updated
+    // after the last backup (catches edits/renames that leave counts unchanged).
     const localMeals = await getAllMeals();
-    status.syncNeeded = localMeals.length !== status.cloudMealCount;
+    const mostRecentLocalChange = localMeals.reduce(
+      (max, m) => Math.max(max, m.updatedAtMs ?? m.date.toMillis()),
+      0
+    );
+    status.syncNeeded =
+      localMeals.length !== status.cloudMealCount ||
+      (status.lastCloudBackup > 0 && mostRecentLocalChange > status.lastCloudBackup);
 
     return status;
 

--- a/src/lib/import/executor.ts
+++ b/src/lib/import/executor.ts
@@ -1,4 +1,4 @@
-import { getAllMeals, saveMeal as saveMealToDb, updateSettings, updateCacheMetadata, type Meal } from '../offline-storage';
+import { getAllMeals, saveMeal as saveMealToDb, updateSettings, updateCacheMetadata, type Meal, type AppSettings } from '../offline-storage';
 import { Timestamp } from 'firebase/firestore';
 import { TagManager } from '../tag-manager';
 import { type SerializableMeal } from '../export-manager';
@@ -90,7 +90,8 @@ export class ImportExecutor {
               date: new Timestamp(mealData.date.seconds, mealData.date.nanoseconds),
               uid: mealData.uid,
               pending: mealData.pending,
-              hidden: mealData.hidden
+              hidden: mealData.hidden,
+              tags: Array.isArray(mealData.tags) ? [...mealData.tags] : undefined
             };
             return saveMealToDb(meal);
           }));
@@ -111,9 +112,21 @@ export class ImportExecutor {
       return false;
     }
 
+    // Only persist known AppSettings keys to avoid polluting the settings store with
+    // stale or renamed fields from older exports.
+    const knownKeys: ReadonlyArray<keyof AppSettings> = [
+      'id', 'theme', 'autoBackupEnabled', 'backupFrequencyDays', 'exportFormat', 'lastExportTimestamp'
+    ];
+    const filtered: Partial<AppSettings> = {};
+    for (const key of knownKeys) {
+      if (key in settings) {
+        (filtered as Record<string, unknown>)[key] = settings[key];
+      }
+    }
+
     try {
       if (!dryRun) {
-        await updateSettings(settings);
+        await updateSettings(filtered);
       }
       return true;
     } catch (error) {

--- a/src/lib/offline-storage.ts
+++ b/src/lib/offline-storage.ts
@@ -241,8 +241,14 @@ export async function getMealById(id: string): Promise<Meal | null> {
   return normalized;
 }
 
-function withLocalSyncMetadata(meal: Meal, existing?: Meal): Meal {
-  const updatedAtMs = meal.updatedAtMs ?? existing?.updatedAtMs ?? Date.now();
+function withLocalSyncMetadata(meal: Meal, existing?: Meal, preserveTimestamp = false): Meal {
+  // Always stamp a fresh timestamp on local writes so the freshness comparison in
+  // cloud-sync never loses a local edit to a stale cloud copy.  Pass
+  // preserveTimestamp=true only when re-saving a meal whose timestamp must not
+  // advance (e.g. initialPullAndMerge re-assigning UID without user edits).
+  const updatedAtMs = preserveTimestamp
+    ? (meal.updatedAtMs ?? existing?.updatedAtMs ?? Date.now())
+    : Date.now();
   return {
     ...meal,
     updatedAtMs,
@@ -294,14 +300,14 @@ async function enqueueMealSync(
 
 export async function saveMeal(
   meal: Meal,
-  options: { skipSyncQueue?: boolean } = {}
+  options: { skipSyncQueue?: boolean; preserveTimestamp?: boolean } = {}
 ): Promise<void> {
   const db = getDb();
   if (!db) return;
 
   const dbInstance = await db;
   const existingMeal = await dbInstance.get('meals', meal.id);
-  const mealToSave = withLocalSyncMetadata(meal, existingMeal ?? undefined);
+  const mealToSave = withLocalSyncMetadata(meal, existingMeal ?? undefined, options.preserveTimestamp);
 
   await dbInstance.put('meals', mealToSave);
 
@@ -518,18 +524,9 @@ export async function deleteMealsByName(
   // Get all meals with this name using the index
   const mealsToDelete = await index.getAll(mealName);
 
-  if (!options.skipSyncQueue) {
-    for (const meal of mealsToDelete) {
-      await enqueueMealSync(dbInstance, {
-        entityType: 'meal',
-        entityId: meal.id,
-        operation: 'delete',
-        targetUid: meal.uid
-      });
-    }
-  }
-
-  // Batch delete all matching meals
+  // Delete within the transaction first, then enqueue sync ops after commit.
+  // This order matches hideMealsByName / updateMealNameByName and avoids
+  // orphaned "delete" sync items if the transaction fails to commit.
   const deletePromises = mealsToDelete.map(meal => store.delete(meal.id));
   await Promise.all(deletePromises);
 
@@ -540,6 +537,17 @@ export async function deleteMealsByName(
   await metaStore.put({ ...existing, mealCount });
 
   await tx.done;
+
+  if (!options.skipSyncQueue) {
+    for (const meal of mealsToDelete) {
+      await enqueueMealSync(dbInstance, {
+        entityType: 'meal',
+        entityId: meal.id,
+        operation: 'delete',
+        targetUid: meal.uid
+      });
+    }
+  }
 }
 
 // === METADATA OPERATIONS ===


### PR DESCRIPTION
- executor.ts: include `tags` field when constructing Meal during import
  (previously dropped all tag assignments silently on every import)
- executor.ts: filter importSettings to known AppSettings keys so stale
  fields from old exports don't pollute the IndexedDB settings store
- offline-storage.ts: always stamp updatedAtMs = Date.now() on local saves
  via new preserveTimestamp option; callers that must preserve the existing
  timestamp (initialPullAndMerge) opt in explicitly
- offline-storage.ts: move deleteMealsByName sync-queue enqueue to after
  tx.done so a failed transaction cannot leave orphaned delete ops that
  cause ghost-resurrection cycles on other devices
- cloud-sync.ts: remove duplicate initialPullAndMerge call in runSignedInSync
  that re-queued all local meals after every flush, creating a self-sustaining
  write storm
- cloud-sync.ts: pass preserveTimestamp:true when re-saving local meals in
  initialPullAndMerge so freshness timestamps are not inflated
- firebase-auth.ts: getCurrentUser now returns auth.currentUser directly from
  the Firebase SDK (always current after sign-in) instead of a stale module
  variable, closing the UID-mismatch window during sign-in
- firestore-backup.ts: syncNeeded now also checks whether any local meal was
  updated after the last backup, not just whether counts differ
- CloudSyncPanel.tsx: hold onMessage in a ref so the polling interval is
  registered once and not torn down on every parent re-render
- TagManagementSection.tsx: catch rejected Promise from async onTagsUpdated
  so IndexedDB failures are surfaced rather than silently discarded

https://claude.ai/code/session_01AEAHjkXW3gP9AzGstpv9nd